### PR TITLE
Add shared and transaction-level lock options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - DB=mysql
   - DB=postgresql
 
+before_install:
+  - gem install bundler
+
 script: WITH_ADVISORY_LOCK_PREFIX=$TRAVIS_JOB_ID bundle exec rake --trace
 
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 platforms :ruby do
   gem 'mysql2'
-  gem 'pg'
+  gem 'pg', '< 0.19' # 0.19 requires Ruby 2.0+
   gem 'sqlite3'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.10' # Rails 3.2 requires 0.3.x
   gem 'pg', '< 0.19' # 0.19 requires Ruby 2.0+
   gem 'sqlite3'
 end

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ the lock cannot be acquired within that time-frame.
 
 For backwards compatability, the timeout value can be specified directly as the second parameter.
 
+### Shared locks
+
+The ```shared``` option defaults to ```false``` which means an exclusive lock will be obtained.
+Setting ```shared``` to ```true``` will allow locks to be obtained by multiple actors
+as long as they are all shared locks.
+
+Note: MySQL does not support shared locks.
+
 ### Return values
 
 The return value of `with_advisory_lock_result` is a `WithAdvisoryLock::Result` instance,

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ end
 
 ### Lock wait timeouts
 
-The second parameter for ```with_advisory_lock``` is ```timeout_seconds```, and defaults to ```nil```,
-which means wait indefinitely for the lock.
+```with_advisory_lock``` takes an options hash as the second parameter.
+The ```timeout_seconds``` option defaults to ```nil```, which means wait indefinitely for the lock.
 
 A value of zero will try the lock only once. If the lock is acquired, the block
 will be yielded to. If the lock is currently being held, the block will not be called.
 
 Note that if a non-nil value is provided for `timeout_seconds`, the block will not be invoked if
 the lock cannot be acquired within that time-frame.
+
+For backwards compatability, the timeout value can be specified directly as the second parameter.
 
 ### Return values
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ as long as they are all shared locks.
 
 Note: MySQL does not support shared locks.
 
+### Transaction-level locks
+
+PostgreSQL supports transaction-level locks which remain held until the transaction completes.
+You can enable this by setting the ```transaction``` option to ```true```.
+
+Note: transaction-level locks will not be reflected by `.current_advisory_lock` when the block has returned.
+
 ### Return values
 
 The return value of `with_advisory_lock_result` is a `WithAdvisoryLock::Result` instance,

--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -6,7 +6,7 @@ gem "activerecord", "~> 3.2.0"
 
 platforms :ruby do
   gem "mysql2"
-  gem "pg"
+  gem "pg", "< 0.19"
   gem "sqlite3"
 end
 

--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 3.2.0"
 
 platforms :ruby do
-  gem "mysql2"
+  gem "mysql2", "~> 0.3.10"
   gem "pg", "< 0.19"
   gem "sqlite3"
 end

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -6,7 +6,7 @@ gem "activerecord", "~> 4.0.0"
 
 platforms :ruby do
   gem "mysql2"
-  gem "pg"
+  gem "pg", "< 0.19"
   gem "sqlite3"
 end
 

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.0.0"
 
 platforms :ruby do
-  gem "mysql2"
+  gem "mysql2", "~> 0.3.10"
   gem "pg", "< 0.19"
   gem "sqlite3"
 end

--- a/gemfiles/activerecord_4.1.gemfile
+++ b/gemfiles/activerecord_4.1.gemfile
@@ -6,7 +6,7 @@ gem "activerecord", "~> 4.1.0"
 
 platforms :ruby do
   gem "mysql2"
-  gem "pg"
+  gem "pg", "< 0.19"
   gem "sqlite3"
 end
 

--- a/gemfiles/activerecord_4.1.gemfile
+++ b/gemfiles/activerecord_4.1.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.1.0"
 
 platforms :ruby do
-  gem "mysql2"
+  gem "mysql2", "~> 0.3.10"
   gem "pg", "< 0.19"
   gem "sqlite3"
 end

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -7,7 +7,7 @@ gem "arel", :github => "rails/arel"
 
 platforms :ruby do
   gem "mysql2"
-  gem "pg"
+  gem "pg", "< 0.19"
   gem "sqlite3"
 end
 

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -6,7 +6,7 @@ gem "activerecord", :github => "rails/rails"
 gem "arel", :github => "rails/arel"
 
 platforms :ruby do
-  gem "mysql2"
+  gem "mysql2", "~> 0.3.10"
   gem "pg", "< 0.19"
   gem "sqlite3"
 end

--- a/lib/with_advisory_lock/base.rb
+++ b/lib/with_advisory_lock/base.rb
@@ -17,15 +17,16 @@ module WithAdvisoryLock
   FAILED_TO_LOCK = Result.new(false)
 
   class Base
-    attr_reader :connection, :lock_name, :timeout_seconds
+    attr_reader :connection, :lock_name, :timeout_seconds, :shared
 
     def initialize(connection, lock_name, options)
       options = {timeout_seconds: options} unless options.respond_to?(:fetch)
-      options.assert_valid_keys :timeout_seconds
+      options.assert_valid_keys :timeout_seconds, :shared
 
       @connection = connection
       @lock_name = lock_name
       @timeout_seconds = options.fetch(:timeout_seconds, nil)
+      @shared = options.fetch(:shared, false)
     end
 
     def lock_str

--- a/lib/with_advisory_lock/base.rb
+++ b/lib/with_advisory_lock/base.rb
@@ -17,16 +17,17 @@ module WithAdvisoryLock
   FAILED_TO_LOCK = Result.new(false)
 
   class Base
-    attr_reader :connection, :lock_name, :timeout_seconds, :shared
+    attr_reader :connection, :lock_name, :timeout_seconds, :shared, :transaction
 
     def initialize(connection, lock_name, options)
       options = {timeout_seconds: options} unless options.respond_to?(:fetch)
-      options.assert_valid_keys :timeout_seconds, :shared
+      options.assert_valid_keys :timeout_seconds, :shared, :transaction
 
       @connection = connection
       @lock_name = lock_name
       @timeout_seconds = options.fetch(:timeout_seconds, nil)
       @shared = options.fetch(:shared, false)
+      @transaction = options.fetch(:transaction, false)
     end
 
     def lock_str

--- a/lib/with_advisory_lock/base.rb
+++ b/lib/with_advisory_lock/base.rb
@@ -19,10 +19,13 @@ module WithAdvisoryLock
   class Base
     attr_reader :connection, :lock_name, :timeout_seconds
 
-    def initialize(connection, lock_name, timeout_seconds)
+    def initialize(connection, lock_name, options)
+      options = {timeout_seconds: options} unless options.respond_to?(:fetch)
+      options.assert_valid_keys :timeout_seconds
+
       @connection = connection
       @lock_name = lock_name
-      @timeout_seconds = timeout_seconds
+      @timeout_seconds = options.fetch(:timeout_seconds, nil)
     end
 
     def lock_str

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -6,13 +6,13 @@ module WithAdvisoryLock
     delegate :with_advisory_lock, :advisory_lock_exists?, to: 'self.class'
 
     module ClassMethods
-      def with_advisory_lock(lock_name, timeout_seconds=nil, &block)
-        result = with_advisory_lock_result(lock_name, timeout_seconds, &block)
+      def with_advisory_lock(lock_name, options={}, &block)
+        result = with_advisory_lock_result(lock_name, options, &block)
         result.lock_was_acquired? ? result.result : false
       end
 
-      def with_advisory_lock_result(lock_name, timeout_seconds=nil, &block)
-        impl = impl_class.new(connection, lock_name, timeout_seconds)
+      def with_advisory_lock_result(lock_name, options={}, &block)
+        impl = impl_class.new(connection, lock_name, options)
         impl.with_advisory_lock_if_needed(&block)
       end
 

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -22,7 +22,8 @@ module WithAdvisoryLock
       end
 
       def current_advisory_lock
-        WithAdvisoryLock::Base.lock_stack.first
+        lock_stack_key = WithAdvisoryLock::Base.lock_stack.first
+        lock_stack_key && lock_stack_key[0]
       end
 
       private

--- a/lib/with_advisory_lock/flock.rb
+++ b/lib/with_advisory_lock/flock.rb
@@ -20,7 +20,7 @@ module WithAdvisoryLock
     end
 
     def try_lock
-      0 == file_io.flock(File::LOCK_EX|File::LOCK_NB)
+      0 == file_io.flock((shared ? File::LOCK_SH : File::LOCK_EX) | File::LOCK_NB)
     end
 
     def release_lock

--- a/lib/with_advisory_lock/flock.rb
+++ b/lib/with_advisory_lock/flock.rb
@@ -20,6 +20,9 @@ module WithAdvisoryLock
     end
 
     def try_lock
+      if transaction
+        raise ArgumentError, 'transaction level locks are not supported on SQLite'
+      end
       0 == file_io.flock((shared ? File::LOCK_SH : File::LOCK_EX) | File::LOCK_NB)
     end
 

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -10,6 +10,9 @@ module WithAdvisoryLock
       if shared
         raise ArgumentError, 'shared locks are not supported on MySQL'
       end
+      if transaction
+        raise ArgumentError, 'transaction level locks are not supported on MySQL'
+      end
       execute_successful?("GET_LOCK(#{quoted_lock_str}, 0)")
     end
 

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -7,6 +7,9 @@ module WithAdvisoryLock
           "MySQL doesn't support nested Advisory Locks",
           lock_stack.dup)
       end
+      if shared
+        raise ArgumentError, 'shared locks are not supported on MySQL'
+      end
       execute_successful?("GET_LOCK(#{quoted_lock_str}, 0)")
     end
 

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -27,7 +27,7 @@ module WithAdvisoryLock
 
     # MySQL doesn't support nested locks:
     def already_locked?
-      lock_stack.last == lock_str
+      lock_stack.last == lock_stack_item
     end
 
     # MySQL wants a string as the lock key.

--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -2,11 +2,12 @@ module WithAdvisoryLock
   class PostgreSQL < Base
     # See http://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
     def try_lock
-      pg_function = "pg_try_advisory_lock#{shared ? '_shared' : ''}"
+      pg_function = "pg_try_advisory#{transaction ? '_xact' : ''}_lock#{shared ? '_shared' : ''}"
       execute_successful?(pg_function)
     end
 
     def release_lock
+      return if transaction
       pg_function = "pg_advisory_unlock#{shared ? '_shared' : ''}"
       execute_successful?(pg_function)
     rescue ActiveRecord::StatementInvalid => e

--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -2,16 +2,18 @@ module WithAdvisoryLock
   class PostgreSQL < Base
     # See http://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
     def try_lock
-      execute_successful?('pg_try_advisory_lock')
+      pg_function = "pg_try_advisory_lock#{shared ? '_shared' : ''}"
+      execute_successful?(pg_function)
     end
 
     def release_lock
-      execute_successful?('pg_advisory_unlock')
+      pg_function = "pg_advisory_unlock#{shared ? '_shared' : ''}"
+      execute_successful?(pg_function)
     rescue ActiveRecord::StatementInvalid => e
       raise unless e.message =~ / ERROR: +current transaction is aborted,/
       begin
         connection.rollback_db_transaction
-        execute_successful?('pg_advisory_unlock')
+        execute_successful?(pg_function)
       ensure
         connection.begin_db_transaction
       end

--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -2,17 +2,11 @@ module WithAdvisoryLock
   class PostgreSQL < Base
     # See http://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
     def try_lock
-      if connection.open_transactions > 0
-        execute_successful?('pg_try_advisory_xact_lock')
-      else
-        execute_successful?('pg_try_advisory_lock')
-      end
+      execute_successful?('pg_try_advisory_lock')
     end
 
     def release_lock
-      if connection.open_transactions <= 0
-        execute_successful?('pg_advisory_unlock')
-      end
+      execute_successful?('pg_advisory_unlock')
     end
 
     def execute_successful?(pg_function)

--- a/test/nesting_test.rb
+++ b/test/nesting_test.rb
@@ -15,12 +15,12 @@ describe "lock nesting" do
     impl = WithAdvisoryLock::Base.new(nil, nil, nil)
     impl.lock_stack.must_be_empty
     Tag.with_advisory_lock("first") do
-      impl.lock_stack.must_equal %w(first)
+      impl.lock_stack.map(&:name).must_equal %w(first)
       # Even MySQL should be OK with this:
       Tag.with_advisory_lock("first") do
-        impl.lock_stack.must_equal %w(first)
+        impl.lock_stack.map(&:name).must_equal %w(first)
       end
-      impl.lock_stack.must_equal %w(first)
+      impl.lock_stack.map(&:name).must_equal %w(first)
     end
     impl.lock_stack.must_be_empty
   end
@@ -33,7 +33,7 @@ describe "lock nesting" do
         end
       end
     }.must_raise WithAdvisoryLock::NestedAdvisoryLockError
-    exc.lock_stack.must_equal %w(first)
+    exc.lock_stack.map(&:name).must_equal %w(first)
   end
 
   it "supports nested advisory locks with !MySQL" do
@@ -41,19 +41,19 @@ describe "lock nesting" do
     impl = WithAdvisoryLock::Base.new(nil, nil, nil)
     impl.lock_stack.must_be_empty
     Tag.with_advisory_lock("first") do
-      impl.lock_stack.must_equal %w(first)
+      impl.lock_stack.map(&:name).must_equal %w(first)
       Tag.with_advisory_lock("second") do
-        impl.lock_stack.must_equal %w(first second)
+        impl.lock_stack.map(&:name).must_equal %w(first second)
         Tag.with_advisory_lock("first") do
           # Shouldn't ask for another lock:
-          impl.lock_stack.must_equal %w(first second)
+          impl.lock_stack.map(&:name).must_equal %w(first second)
           Tag.with_advisory_lock("second") do
             # Shouldn't ask for another lock:
-            impl.lock_stack.must_equal %w(first second)
+            impl.lock_stack.map(&:name).must_equal %w(first second)
           end
         end
       end
-      impl.lock_stack.must_equal %w(first)
+      impl.lock_stack.map(&:name).must_equal %w(first)
     end
     impl.lock_stack.must_be_empty
   end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -9,18 +9,21 @@ describe 'options parsing' do
     impl = parse_options({})
     impl.timeout_seconds.must_equal nil
     impl.shared.must_equal false
+    impl.transaction.must_equal false
   end
 
   specify 'nil sets timeout to nil' do
     impl = parse_options(nil)
     impl.timeout_seconds.must_equal nil
     impl.shared.must_equal false
+    impl.transaction.must_equal false
   end
 
   specify 'integer sets timeout to value' do
     impl = parse_options(42)
     impl.timeout_seconds.must_equal 42
     impl.shared.must_equal false
+    impl.transaction.must_equal false
   end
 
   specify 'hash with invalid key errors' do
@@ -33,12 +36,21 @@ describe 'options parsing' do
     impl = parse_options(timeout_seconds: 123)
     impl.timeout_seconds.must_equal 123
     impl.shared.must_equal false
+    impl.transaction.must_equal false
   end
 
   specify 'hash with shared option sets shared to true' do
     impl = parse_options(shared: true)
     impl.timeout_seconds.must_equal nil
     impl.shared.must_equal true
+    impl.transaction.must_equal false
+  end
+
+  specify 'hash with transaction option set transaction to true' do
+    impl = parse_options(transaction: true)
+    impl.timeout_seconds.must_equal nil
+    impl.shared.must_equal false
+    impl.transaction.must_equal true
   end
 
   specify 'hash with multiple keys sets options' do
@@ -47,5 +59,6 @@ describe 'options parsing' do
     impl = parse_options(timeout_seconds: foo, shared: bar)
     impl.timeout_seconds.must_equal foo
     impl.shared.must_equal bar
+    impl.transaction.must_equal false
   end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -8,16 +8,19 @@ describe 'options parsing' do
   specify 'defaults (empty hash)' do
     impl = parse_options({})
     impl.timeout_seconds.must_equal nil
+    impl.shared.must_equal false
   end
 
   specify 'nil sets timeout to nil' do
     impl = parse_options(nil)
     impl.timeout_seconds.must_equal nil
+    impl.shared.must_equal false
   end
 
   specify 'integer sets timeout to value' do
     impl = parse_options(42)
     impl.timeout_seconds.must_equal 42
+    impl.shared.must_equal false
   end
 
   specify 'hash with invalid key errors' do
@@ -29,5 +32,20 @@ describe 'options parsing' do
   specify 'hash with timeout_seconds sets timeout to value' do
     impl = parse_options(timeout_seconds: 123)
     impl.timeout_seconds.must_equal 123
+    impl.shared.must_equal false
+  end
+
+  specify 'hash with shared option sets shared to true' do
+    impl = parse_options(shared: true)
+    impl.timeout_seconds.must_equal nil
+    impl.shared.must_equal true
+  end
+
+  specify 'hash with multiple keys sets options' do
+    foo = mock
+    bar = mock
+    impl = parse_options(timeout_seconds: foo, shared: bar)
+    impl.timeout_seconds.must_equal foo
+    impl.shared.must_equal bar
   end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -1,0 +1,33 @@
+require 'minitest_helper'
+
+describe 'options parsing' do
+  def parse_options(options)
+    WithAdvisoryLock::Base.new(mock, mock, options)
+  end
+
+  specify 'defaults (empty hash)' do
+    impl = parse_options({})
+    impl.timeout_seconds.must_equal nil
+  end
+
+  specify 'nil sets timeout to nil' do
+    impl = parse_options(nil)
+    impl.timeout_seconds.must_equal nil
+  end
+
+  specify 'integer sets timeout to value' do
+    impl = parse_options(42)
+    impl.timeout_seconds.must_equal 42
+  end
+
+  specify 'hash with invalid key errors' do
+    proc {
+      parse_options(foo: 42)
+    }.must_raise ArgumentError
+  end
+
+  specify 'hash with timeout_seconds sets timeout to value' do
+    impl = parse_options(timeout_seconds: 123)
+    impl.timeout_seconds.must_equal 123
+  end
+end

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -1,0 +1,110 @@
+require 'minitest_helper'
+
+describe 'shared locks' do
+  def supported?
+    env_db != :mysql
+  end
+
+  class SharedTestWorker
+    def initialize(shared)
+      @shared = shared
+
+      @locked = nil
+      @cleanup = false
+      @thread = Thread.new { work }
+    end
+
+    def locked?
+      sleep 0.01 while @locked.nil? && @thread.alive?
+      @locked
+    end
+
+    def cleanup!
+      @cleanup = true
+      @thread.join
+      raise if @thread.status.nil?
+    end
+
+    private
+
+    def work
+      ActiveRecord::Base.connection_pool.with_connection do
+        Tag.with_advisory_lock('test', timeout_seconds: 0, shared: @shared) do
+          @locked = true
+          sleep 0.01 until @cleanup
+        end
+        @locked = false
+        sleep 0.01 until @cleanup
+      end
+    end
+  end
+
+  it 'does not allow two exclusive locks' do
+    one = SharedTestWorker.new(false)
+    one.locked?.must_equal true
+
+    two = SharedTestWorker.new(false)
+    two.locked?.must_equal false
+
+    one.cleanup!
+    two.cleanup!
+  end
+
+  describe 'not supported' do
+    before do
+      skip if supported?
+    end
+
+    it 'raises an error when attempting to use a shared lock' do
+      one = SharedTestWorker.new(true)
+      one.locked?.must_equal nil
+      exception = proc {
+        one.cleanup!
+      }.must_raise ArgumentError
+      exception.message.must_include 'not supported'
+    end
+  end
+
+  describe 'supported' do
+    before do
+      skip unless supported?
+    end
+
+    it 'does allow two shared locks' do
+      one = SharedTestWorker.new(true)
+      one.locked?.must_equal true
+
+      two = SharedTestWorker.new(true)
+      two.locked?.must_equal true
+
+      one.cleanup!
+      two.cleanup!
+    end
+
+    it 'does not allow exclusive lock with shared lock' do
+      one = SharedTestWorker.new(true)
+      one.locked?.must_equal true
+
+      two = SharedTestWorker.new(false)
+      two.locked?.must_equal false
+
+      three = SharedTestWorker.new(true)
+      three.locked?.must_equal true
+
+      one.cleanup!
+      two.cleanup!
+      three.cleanup!
+    end
+
+    it 'does not allow shared lock with exclusive lock' do
+      one = SharedTestWorker.new(false)
+      one.locked?.must_equal true
+
+      two = SharedTestWorker.new(true)
+      two.locked?.must_equal false
+
+      one.cleanup!
+      two.cleanup!
+    end
+  end
+end

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -23,5 +23,20 @@ describe 'transaction scoping' do
         pg_lock_count.must_equal 0
       end
     end
+
+    specify 'session locks release when transaction fails inside block' do
+      Tag.transaction do
+        pg_lock_count.must_equal 0
+
+        exception = proc {
+          Tag.with_advisory_lock 'test' do
+            Tag.connection.execute 'SELECT 1/0;'
+          end
+        }.must_raise ActiveRecord::StatementInvalid
+        exception.message.must_include 'division by zero'
+
+        pg_lock_count.must_equal 0
+      end
+    end
   end
 end

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -1,0 +1,27 @@
+require 'minitest_helper'
+
+describe 'transaction scoping' do
+  def supported?
+    env_db == :postgresql
+  end
+
+  describe 'supported' do
+    before do
+      skip unless env_db == :postgresql
+    end
+
+    def pg_lock_count
+      ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory';").to_i
+    end
+
+    specify 'session locks release after the block executes' do
+      Tag.transaction do
+        pg_lock_count.must_equal 0
+        Tag.with_advisory_lock 'test' do
+          pg_lock_count.must_equal 1
+        end
+        pg_lock_count.must_equal 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces opt-in options for shared locks (PostgreSQL and SQLite) and transaction-level locks (PostgreSQL). These features can be enabled by passing in an options hash to `with_advisory_lock`.

Shared locks allow multiple connections to obtain a lock at once as long as no other connection has an exclusive lock. Exclusive locks remain the default. A typical use case would be using an exclusive lock when making changes to shared date and shared locks when reading from the shared state.

Transaction-level locks persist until the database transaction completes instead of when the block returns. These have been made opt-in due to potential compatibility issues (one may wish to release the lock before completing the transaction) and because they break the `.current_advisory_lock` feature.

Additionally, a bug where session locks fail to release when the transaction is in an invalid state has been fixed. When the unlock fails with `PG::InFailedSqlTransaction`, the unlock is retried after rolling back the failed transaction. Fixes #14.